### PR TITLE
Js based branch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # joomla-article-custom-field
-Joomla plugin to add a custom field to a selected category
+Joomla plugin to add a custom field to a selected category.
+This plugin was created after [this question](http://joomla.stackexchange.com/questions/15764/article-custom-fields-for-one-category/15766?noredirect=1#comment19963_15766) on joomla.stackexchange.com.
+
+##Instalation
+1. [download ZIP](https://github.com/web-tiki/joomla-article-custom-field/archive/master.zip)
+2. go to your admin panel and navigate to Extensiosn -> Manage and "Upload Package File" tab.
+3. choose the downloaded .zip file and click "Upload & Install"
+4. navigate to the plugin manager Extensiosn -> Plugins and search for "Content - ACF Article Custom Field"
+5. enable the plugin and select the joomla category you need apply the custom field to
+6. create a new article and select the category
+7. save the article
+8. a new tab called "Custom field" appears with the custom field
+
+At this point, you are able to save the custom field value in the  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# joomla-article-custom-field
+# Joomla article custom fields
 Joomla plugin to add a custom field to a selected category.
 This plugin was created after [this question](http://joomla.stackexchange.com/questions/15764/article-custom-fields-for-one-category/15766?noredirect=1#comment19963_15766) on joomla.stackexchange.com.
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,53 @@ This plugin was created after [this question](http://joomla.stackexchange.com/qu
 
 ##Instalation
 1. [download ZIP](https://github.com/web-tiki/joomla-article-custom-field/archive/master.zip)
-2. go to your admin panel and navigate to Extensiosn -> Manage and "Upload Package File" tab.
+2. go to your admin panel and navigate to Extensions -> Manage and "Upload Package File" tab.
 3. choose the downloaded .zip file and click "Upload & Install"
-4. navigate to the plugin manager Extensiosn -> Plugins and search for "Content - ACF Article Custom Field"
+4. navigate to the plugin manager Extensions -> Plugins and search for "Content - ACF Article Custom Field"
 5. enable the plugin and select the joomla category you need apply the custom field to
 6. create a new article and select the category
-7. save the article
-8. a new tab called "Custom field" appears with the custom field
+7. under the "Custom field" tab, there is a custom text field
 
-At this point, you are able to save the custom field value in the  
+At this point, you are able to save the custom field value in the article params.
+
+##Display the custom field value
+
+Create a template override for the article. In `defaul.php` add the following code where you want the custom field to be displayed:
+
+
+    <?php if ($this->item->params->get('custom_field1')) : ?>
+	    <div class="custom_field1">
+		    <?php echo $this->item->params->get('custom_field1'); ?>
+	    </div>
+    <?php endif; ?>
+
+
+## Adding custom fields to the plugin
+
+To add custom fields, you need to edit the `forms/content.xml` file. You can use joomla standard form field types (see [here](https://docs.joomla.org/Standard_form_field_types)).
+
+Here are a few examples :
+
+###Add a custom image field:
+
+    <field
+      name="custom_field_image"
+      type="media"
+      label="Custom image"
+      description="Select a custom image"
+      />
+
+More info on the Media form field type [here](https://docs.joomla.org/Media_form_field_type).        
+
+###Add a custom pdf document:
+
+    <field
+      type="filelist"
+      name="custom_pdf_path"
+      label="Custom PDF file"
+      directory="images/documents"
+      filter="\.pdf$"
+      hide_default="true"
+      />
+
+This will output a select element and allow the selection of pdf files in the `images/documents` directory. The field will store the pdf name with extension. More info on the filelist form field type [here](https://docs.joomla.org/Filelist_form_field_type)

--- a/acf.php
+++ b/acf.php
@@ -6,34 +6,64 @@
  */
 
 // Protect from unauthorized access
-defined ('_JEXEC') or die ('Restricted access');
+defined ( '_JEXEC' ) or die ( 'Restricted access' );
 
-class plgContentAcf extends JPlugin 
-{
+class plgContentAcf extends JPlugin {
 	protected $autoloadLanguage = true;
 
 	function onContentPrepareForm($form, $data)
 	{
 		$app = JFactory::getApplication();
-
-		if ($app->isAdmin())
-		{
-			$option = $app->input->get('option');
-			$view   = $app->input->get('view');
-
-			if ($option === 'com_content' && $view === 'article')
+		$option = $app->input->get('option');
+		switch($option) {
+			case 'com_content':
+			if ($app->isAdmin())
 			{
+				JForm::addFormPath(__DIR__ . '/forms');
+				$form->loadFile('content', false);
+
 				$model = JModelLegacy::getInstance('Article', 'ContentModel');
 				$catid = $model->getItem($app->input->get('id'))->catid;
 
-				if ($this->params->get('category') === $catid)
-				{
-					JForm::addFormPath(__DIR__ . '/forms');
-					$form->loadFile('content', false);
-				}
-			}
+				$pluginCatId = $this->params->get('category');
 
+				$document = JFactory::getDocument();
+				$document->addScriptDeclaration('
+				jQuery( document ).ready(function() {
+					var selectedCategory = jQuery("#jform_catid").val(),
+							catId = ' . $catid . ',
+							pluginCat = ' . $pluginCatId . ',
+							fields = jQuery("#attrib-acf .controls"),
+							labels = jQuery("#attrib-acf .control-label"),
+							warningMessage = jQuery("#attrib-acf .control-group .acf_warningMessage");
+
+
+					jQuery("#jform_catid").change(function() {
+						selectedCategory = jQuery("#jform_catid").val();
+						if(selectedCategory != pluginCat){
+							fields.hide();
+							labels.hide();
+							warningMessage.show();
+						} else {
+							fields.show();
+							labels.show();
+							warningMessage.hide();
+						}
+					});
+
+					if(selectedCategory != pluginCat){
+						fields.hide();
+						labels.hide();
+					} else {
+						warningMessage.hide();
+					}
+
+				});
+				');
+			}
 			return true;
 		}
+		return true;
 	}
 }
+?>

--- a/acf.xml
+++ b/acf.xml
@@ -8,7 +8,7 @@
 	<authorEmail>contact@web-tiki.com</authorEmail>
 	<authorUrl>http://web-tiki.com</authorUrl>
 	<version>1.0.0</version>
-	<description>This plugin adds a custom field to articles. Enable it and select a category. More info <a href="https://github.com/web-tiki/joomla-article-custom-field">here</a>.</description>
+	<description>This plugin adds a custom field to articles. Enable it and select a category. More info &lt;a target="_blank" href="https://github.com/web-tiki/joomla-article-custom-field"&gt;here&lt;/a&gt;.</description>
 	<files>
 		<filename plugin="acf">acf.php</filename>
 		<filename>index.html</filename>

--- a/en-GB.plg_content_acf.ini
+++ b/en-GB.plg_content_acf.ini
@@ -1,7 +1,8 @@
-COM_CONTENT_ACF_FIELDSET_LABEL="Custom field"
+COM_CONTENT_ACF_FIELDSET_LABEL = "Custom field"
 
-PLG_CONTENT_ACF="Content - ACF Article Custom Field"
+PLG_CONTENT_ACF = "Content - ACF Article Custom Field"
 
-PLG_CONTENT_ACF_OPTION_CATEGORY="Select a category"
-PLG_CONTENT_ACF_CUSTOM_FIEL1_LABEL="Text"
-PLG_CONTENT_ACF_CUSTOM_FIEL1_DESC="Custom field description"
+PLG_CONTENT_ACF_OPTION_CATEGORY = "Select a category"
+PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL = "Text"
+PLG_CONTENT_ACF_CUSTOM_FIELD1_DESC = "Custom field description"
+PLG_CONTENT_ACF_WARNING_MESSAGE = "The selected category has no custom field assigned to it. Please change the ACF plugin settings."

--- a/en-GB.plg_content_acf.ini
+++ b/en-GB.plg_content_acf.ini
@@ -3,6 +3,6 @@ COM_CONTENT_ACF_FIELDSET_LABEL = "Custom field"
 PLG_CONTENT_ACF = "Content - ACF Article Custom Field"
 
 PLG_CONTENT_ACF_OPTION_CATEGORY = "Select a category"
-PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL = "Text"
+PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL = "Custom text field"
 PLG_CONTENT_ACF_CUSTOM_FIELD1_DESC = "Custom field description"
 PLG_CONTENT_ACF_WARNING_MESSAGE = "The selected category has no custom field assigned to it. Please change the ACF plugin settings."

--- a/en-GB.plg_content_acf.sys.ini
+++ b/en-GB.plg_content_acf.sys.ini
@@ -1,7 +1,8 @@
-COM_CONTENT_ACF_FIELDSET_LABEL="Custom field"
+COM_CONTENT_ACF_FIELDSET_LABEL = "Custom field"
 
-PLG_CONTENT_ACF="Content - ACF Article Custom Field"
+PLG_CONTENT_ACF = "Content - ACF Article Custom Field"
 
-PLG_CONTENT_ACF_OPTION_CATEGORY="Select a category"
-PLG_CONTENT_ACF_CUSTOM_FIEL1_LABEL="Text"
-PLG_CONTENT_ACF_CUSTOM_FIEL1_DESC="Custom field description"
+PLG_CONTENT_ACF_OPTION_CATEGORY = "Select a category"
+PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL = "Custom text field"
+PLG_CONTENT_ACF_CUSTOM_FIELD1_DESC = "Custom field description"
+PLG_CONTENT_ACF_WARNING_MESSAGE = "The selected category has no custom field assigned to it. Please change the ACF plugin settings."

--- a/forms/content.xml
+++ b/forms/content.xml
@@ -3,10 +3,17 @@
 	<fields name="attribs">
 		<fieldset name="acf">
 			<field
+				name="warningMessage"
+				type="note"
+				description=""
+				label="PLG_CONTENT_ACF_WARNING_MESSAGE"
+				class="acf_warningMessage"
+				/>
+			<field
 				name="anchor"
 				type="text"
-				label="PLG_CONTENT_ACF_CUSTOM_FIEL1_LABEL"
-				description="PLG_CONTENT_ACF_CUSTOM_FIEL1_DESC"
+				label="PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL"
+				description="PLG_CONTENT_ACF_CUSTOM_FIELD1_DESC"
 				/>
 		</fieldset>
 	</fields>

--- a/forms/content.xml
+++ b/forms/content.xml
@@ -10,7 +10,7 @@
 				class="acf_warningMessage"
 				/>
 			<field
-				name="anchor"
+				name="custom_field1"
 				type="text"
 				label="PLG_CONTENT_ACF_CUSTOM_FIELD1_LABEL"
 				description="PLG_CONTENT_ACF_CUSTOM_FIELD1_DESC"

--- a/forms/index.html
+++ b/forms/index.html
@@ -1,0 +1,4 @@
+<html>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Made another branch with a JS based approach to make the fields appear only on selected categories.
I also added some explanation to add custom fields.
I am not used to plugin development so I would be greatfull if you can take a look @C-Lodder and tell me if I made obvious mistakes.

I am aware this approach has several issues  example:
- if a value is saved in the custom field and the category is changed afterwards. The value isn't  accessible anymore and will still be displayed in the article. (I am thinking of adding another check on the article override to check the category is the same as the ACF selected one)
- It can't handle mandatory fields as the warning will be displayed also for categories that don't need the fields and prevent article saving.
- ...
